### PR TITLE
[FIX]: Corrected array checking

### DIFF
--- a/generate_index.js
+++ b/generate_index.js
@@ -14,7 +14,7 @@ spells.forEach( (spell, ind) => {
       const indexValue = spell[index];
       if(!output[indexValue]) output[indexValue] = [];
       output[indexValue].push(ind);
-    } else if(typeof spell[index] === 'array'){
+    } else if(spell[index] instanceof Array){
       const indiceValues = spell[index];
       for(let i = 0; i < indiceValues.length; i++) {
         const indexValue = spell[index][i];


### PR DESCRIPTION
With the current logic, the classes array is never iterated over because checking the `typeof` of an array returns `object`.

Changed this to use `instanceof Array` instead.